### PR TITLE
added -skipauth switch

### DIFF
--- a/CAM.psm1
+++ b/CAM.psm1
@@ -550,10 +550,14 @@ param(
     [parameter()]
     [switch]$ReturnOutput,
     [parameter()]
+    [switch]$SkipAuth,
+    [parameter()]
     $CAMConfig = $script:CAMConfig
 )
-    if (!(LoggedIn -CAMConfig $CAMConfig)) {
-        Authenticate-ToKeyVault -CAMConfig $CAMConfig
+    if (!$SkipAuth) {
+        if (!(LoggedIn -CAMConfig $CAMConfig)) {
+            Authenticate-ToKeyVault -CAMConfig $CAMConfig
+        }
     }
     if ($CertVersion) {
     	$Cert = Get-PrivateKeyVaultCert -CertName $CertName -CertVersion $CertVersion -CAMConfig $CamConfig
@@ -643,12 +647,16 @@ param(
     [parameter()]
     [switch]$ReturnOutput,
     [parameter()]
+    [switch]$SkipAuth,
+    [parameter()]
     [bool]$Unstructured = $false,
     [parameter()]
     $CAMConfig = $script:CAMConfig
 )
-    if (!(LoggedIn -CAMConfig $CAMConfig)) {
-        Authenticate-ToKeyVault -CAMConfig $CAMConfig
+    if (!$SkipAuth) {
+        if (!(LoggedIn -CAMConfig $CAMConfig)) {
+            Authenticate-ToKeyVault -CAMConfig $CAMConfig
+        }
     }
     if ($CertVersion) {
     	$Secret = Get-PrivateKeyVaultCert -CertName $CertName -CertVersion $CertVersion -CAMConfig $CamConfig


### PR DESCRIPTION
adding -skipauth switch to install-kvcertificateobject and install-kvsecretobject cmdlets to allow calling to the key vault without first confirming that the current context matches the configured context.