### PR TITLE
Event Logs to Integration 

### DIFF
--- a/CAM.psm1
+++ b/CAM.psm1
@@ -47,7 +47,10 @@ function New-CAMConfig() {
         [string]$KeyVault,
 
         [parameter(mandatory=$true)]
-        [string]$Environment
+        [string]$Environment,
+
+        [parameter()]
+        [bool]$LogToWindowsEventLog = $false
     )
 
     return [PSCustomObject]@{
@@ -59,11 +62,92 @@ function New-CAMConfig() {
         KeyVaultCertificatePassword = $KeyVaultCertificatePassword
         KeyVault = $KeyVault
         Environment = $Environment
+        LogToWindowsEventLog = $LogToWindowsEventLog
     }
 }
 
 # END CONSTRUCTORS
 
+# LOG FUNCTIONS
+
+# END LOG FUNCTIONS
+
+function Write-InfoLog {
+    param(
+        [parameter(Mandatory=$true)]
+        [string]$Message,
+        [parameter(Mandatory=$true)]
+        [int]$EventId,
+        [parameter()]
+        [bool]$OnlyEvent,
+        [parameter()]
+        [PSTypeName("CAMConfig")]$CAMConfig = $script:CAMConfig 
+    )
+    Write-CAMEventLog -Message $Message -Type "Information" -EventId $EventId -OnlyEvent $OnlyEvent -CAMConfig $CAMConfig
+}
+
+function Write-WarningLog {
+    param(
+        [parameter(Mandatory=$true)]
+        [string]$Message,
+        [parameter(Mandatory=$true)]
+        [int]$EventId,
+        [parameter()]
+        [bool]$OnlyEvent,
+        [parameter()]
+        [PSTypeName("CAMConfig")]$CAMConfig = $script:CAMConfig 
+    )
+    Write-CAMEventLog -Message $Message -Type "Warning" -EventId $EventId -Error $true -OnlyEvent $OnlyEvent -CAMConfig $CAMConfig
+}
+
+function Write-ErrorLog {
+    param(
+        [parameter(Mandatory=$true)]
+        [string]$Message,
+        [parameter(Mandatory=$true)]
+        [int]$EventId,
+        [parameter()]
+        [bool]$OnlyEvent,
+        [parameter()]
+        [PSTypeName("CAMConfig")]$CAMConfig = $script:CAMConfig 
+    )
+    Write-CAMEventLog -Message $Message -Type "Error" -EventId $EventId -OnlyEvent $OnlyEvent -CAMConfig $CAMConfig
+}
+
+function Write-CAMEventLog {
+    param(
+        [parameter(Mandatory=$true)]
+        [string]$Message,
+        [parameter(Mandatory=$true)]
+        [string]$Type,
+        [parameter(Mandatory=$true)]
+        [int]$EventId,
+        [parameter()]
+        [bool]$Error,
+        [parameter()]
+        [bool]$OnlyEvent,
+        [parameter()]
+        [PSTypeName("CAMConfig")]$CAMConfig = $script:CAMConfig 
+    )
+    if (!$OnlyEvent){
+        if (!$Error) {
+            Write-Output $Message
+        }
+        else {
+            Write-Error $Message
+        }
+    }
+    if ($CAMConfig.LogToWindowsEventLog){
+        if (((Get-EventLog -List).Log.Contains("CertificateAllocationModule"))){
+            New-EventLog -LogName "Application" -Source "CertificateAllocationModule"
+        }
+        Write-EventLog -LogName Application -EventID $EventId `
+            -EntryType $Type -Source "CertificateAllocationModule" -Message $Message
+    }
+}
+
+
+#>
 # SETUP FUNCTIONS
 
 # Script level variable for fallbacks during development, should store these in config or pass in to individual functions.
@@ -105,10 +189,14 @@ Param(
             return $PfxFriendlyName
         }
         catch {
+            Write-ErrorLog -Message "certificate $($CAMConfig.KeyVaultCertificate) could not be imported with given password"`
+                 -EventId 2001 -OnlyEvent $true -CAMConfig $CAMConfig
             throw "certificate $($CAMConfig.KeyVaultCertificate) could not be imported with given password"
         }
     }
     else {
+        Write-ErrorLog -Message "AAD App certificate was not found at $($Path)"`
+                 -EventId 2002 -OnlyEvent $true -CAMConfig $CAMConfig
         throw "AAD App certificate was not found at $($Path)"
     }
 }
@@ -140,6 +228,7 @@ param(
         $script:CAMConfig.KeyVaultCertificatePassword = $CAMConfig.KeyVaultCertificatePassword
         $script:CAMConfig.KeyVault = $CAMConfig.KeyVault
         $script:CAMConfig.Environment = $CAMConfig.Environment
+        $script:CAMConfig.LogToWindowsEventLog = $CAMConfig.LogToWindowsEventLog
         return
     }
     if (Test-Path "$($Path)\CAMConfig.json") {
@@ -157,14 +246,22 @@ param(
             }
             $script:CAMConfig.KeyVault = $Json.KeyVault
             $script:CAMConfig.Environment = $Json.Environment
+            if ($Json.LogToWindowsEventLog) {
+                $script:CAMConfig.LogToWindowsEventLog = $Json.LogToWindowsEventLog
+            }
+            else {
+                $script:CAMConfig.LogToWindowsEventLog = $false
+            }
             return $true
         }
         catch {
-            write-error "Unable to read config at $($Path)\CAMConfig.json, defaulting to hardcoded fallback values." 
+            Write-WarningLog -Message "Unable to read config at $($Path)\CAMConfig.json, defaulting to hardcoded fallback values."
+                -EventId 2003 -CAMConfig $CAMConfig
         }
     }
     else {
-        write-error "Unable to read config at $($Path)\CAMConfig.json, defaulting to hardcoded fallback values."
+        Write-WarningLog -Message "Unable to read config at $($Path)\CAMConfig.json, defaulting to hardcoded fallback values."
+                -EventId 2003 -CAMConfig $CAMConfig
     }
 }
 
@@ -204,7 +301,8 @@ param(
         return $true
     }
     catch {
-        write-error "Unable to schedule CAM task. Exception $_"
+        Write-WarningLog -Message "Unable to schedule CAM task. Exception $_"
+            -EventId 2004
     }
 }
 
@@ -230,7 +328,7 @@ function Authenticate-WithUserProfile() {
         Import-AzureRmContext -Path "$Path\profile.ctx" -ErrorAction Stop
     }
     else {
-        write-output 'Please log into Azure now'
+        Write-InfoLog -Message "Please log into Azure now" -EventId 1001
 	    Login-AzureRMAccount -ErrorAction stop
     }
 }
@@ -255,6 +353,7 @@ param(
         Login-AzureRmAccount -ServicePrincipal -CertificateThumbprint $KeyVaultCertificateThumbprint -ApplicationId $CAMConfig.AADApplicationID -TenantId $CAMConfig.TenantId -ErrorAction Stop
     }
     catch {
+        Write-ErrorLog "Unable to login with Certificate $($CAMConfig.KeyVaultCertificate). Error: $_" -Message -EventId 2005 -OnlyEvent $true -CAMConfig $CAMConfig 
         throw "Unable to login with Certificate $($CAMConfig.KeyVaultCertificate). Error: $_"
     }
 }
@@ -283,6 +382,7 @@ param(
         Login-AzureRmAccount -Credential $Credential -Tenant $CAMConfig.TenantId -ServicePrincipal -ErrorAction Stop
     }
     catch {
+        Write-ErrorLog "Unable to login with Key. Error: $_" -Message -EventId 2006 -OnlyEvent $true -CAMConfig $CAMConfig         
         throw "Unable to login with Key. Error: $_"
     }
 }
@@ -354,7 +454,7 @@ param(
     #    $CAMConfig.KeyVault = $Manifest.KeyVault
     #}
 
-    write-output "CAM: Config loaded"
+    Write-InfoLog -Message "CAM: Config loaded" -EventId 1002 -CAMConfig $CAMConfig
 
     #If certificate authentication is being used, install the required certificate
     if ($CAMConfig.KeyVaultCertificate -and $CAMConfig.KeyVaultCertificatePassword) {
@@ -364,7 +464,7 @@ param(
     #Authenticate with AAD App and KeyVault
     Authenticate-ToKeyVault -CAMConfig $CAMConfig | Out-Null
 
-    write-output "CAM: Authenticated to KeyVault"
+    Write-InfoLog -Message  "CAM: Authenticated to KeyVault" -EventId 1003 -CAMConfig $CAMConfig    
 
     # local path passed in
     if ($LocalManifest) { 
@@ -376,7 +476,7 @@ param(
             $json = $Manifest
         }
         else {
-            write-output "CAM: Manifest object was not of type System.Management.Automation.PSCustomObject"
+            Write-ErrorLog "CAM: Manifest object was not of type System.Management.Automation.PSCustomObject" -EventId 2007 -CAMConfig $CAMConfig
             return
         }
     }
@@ -391,7 +491,7 @@ param(
     $ManifestName = ""
     $DefaultKeyVault = $CAMConfig.KeyVault
 
-    write-output "CAM: $($ManifestName)Manifest loaded"
+    Write-InfoLog -Message  "CAM: $($ManifestName)Manifest loaded" -EventId 1004 -CAMConfig $CAMConfig    
 
     # Iterate through Certificates section 
     if ($null -ne $json.certificates) {
@@ -421,7 +521,8 @@ param(
                 foreach ($deployment in $CertificateVersion.Deploy) {
                     if ($deployment -eq "True" -or $deployment -eq $CAMConfig.Environment) { 
                         # Install Certificate
-                        write-output "CAM: Installing Certificate: $($CertificateName)"
+                        Write-InfoLog -Message  "CAM: Installing Certificate: $($CertificateName)" -EventId 1005 -CAMConfig $CAMConfig    
+                        
                         Install-KVCertificateObject -CertName $CertificateName -CertVersion $CertificateVersion.CertVersion `
                             -CertStoreName $CertificateStoreName -CertStoreLocation $CertificateStoreLocation `
                             -KeyStorageFlags $KeyStorageFlags -Export $Certificate.Export -PublicKeyOnly $PublicKeyOnly -CAMConfig $CAMConfig
@@ -435,7 +536,7 @@ param(
                 }
                 # Delete Certificate
                 if (!$downloaded) {
-                    write-output "CAM: Deleting Certificate: $($CertificateName)"
+                    Write-InfoLog -Message  "CAM: Deleting Certificate: $($CertificateName)" -EventId 1006 -CAMConfig $CAMConfig    
                     $RetrievedCertificate = Get-AzureKeyVaultCertificate -VaultName $CAMConfig.KeyVault -Name $CertificateName -Version $CertificateVersion.CertVersion
                     Remove-Certificate -certName $CertificateName -CertStoreLocation $CertificateStoreLocation `
                      -CertStoreName $CertificateStoreName -certThumbprint $RetrievedCertificate.Thumbprint
@@ -482,7 +583,7 @@ param(
                 foreach ($deployment in $CertificateVersion.Deploy) {
                     if ($deployment -eq "True" -or $deployment -eq $CAMConfig.Environment) { 
                         # Install Certificate
-                        write-output "CAM: Installing Certificate: $($CertificateName)"
+                        Write-InfoLog -Message  "CAM: Installing Certificate: $($CertificateName)" -EventId 1005 -CAMConfig $CAMConfig    
                         Install-KVSecretObject -CertName $CertificateName -CertVersion $CertificateVersion.CertVersion `
                             -CertStoreName $CertificateStoreName -CertStoreLocation $CertificateStoreLocation -Unstructured $Unstructured `
 			                -KeyStorageFlags $KeyStorageFlags -Export $Secret.Export -PublicKeyOnly $PublicKeyOnly -CAMConfig $CAMConfig
@@ -496,7 +597,7 @@ param(
                 }
                 # Delete Certificate
                 if (!$download) {
-                    write-output "CAM: Deleting Certificate: $($CertificateName)"
+                    Write-InfoLog -Message  "CAM: Deleting Certificate: $($CertificateName)" -EventId 1006 -CAMConfig $CAMConfig 
                     $Thumbprint = Get-SecretThumbprint -CertName $CertificateName -CertVersion $CertificateVersion.CertVersion -Unstructured $Unstructured -CAMConfig $CAMConfig
                     Remove-Certificate -CertName $CertificateName -CertStoreLocation $CertificateStoreLocation`
                      -CertStoreName $CertificateStoreName -CertThumbprint $Thumbprint
@@ -566,7 +667,7 @@ param(
     	$Cert = Get-PrivateKeyVaultCert -CertName $CertName -CAMConfig $CamConfig
     }
     if (-not $Cert) {
-        write-output "CAM: Certificate $($certName) does not exist in $($CAMConfig.KeyVault) KeyVault"
+        Write-ErrorLog -Message  "CAM: Certificate $($certName) does not exist in $($CAMConfig.KeyVault) KeyVault" -EventId 2008 -CAMConfig $CAMConfig 
         return
     }
     try {
@@ -577,7 +678,7 @@ param(
         }
     }
     catch {
-        write-output "CAM: Certificate $Certname could not be imported with password. Exception: $_"
+        Write-ErrorLog -Message "CAM: Certificate $Certname could not be imported with password. Exception: $_" -EventId 2009 -CAMConfig $CAMConfig         
         return
     }
     $Pfx.FriendlyName = $CertName
@@ -594,7 +695,7 @@ param(
         Thumbprint=$pfx.Thumbprint
     }
     $Pfx.Dispose()
-    write-output "CAM: Installed Certificate $($CertName) to $CertStoreLocation\$CertStoreName store"
+    Write-InfoLog -Message "CAM: Installed Certificate $($CertName) to $CertStoreLocation\$CertStoreName store" -EventId 1007 -CAMConfig $CAMConfig             
     if ($ReturnOutput) {
         return $Output
     }
@@ -665,7 +766,7 @@ param(
     	$Secret = Get-PrivateKeyVaultCert -CertName $CertName -CAMConfig $CamConfig
     }
     if (-not $Secret) {
-        write-output "CAM: Certificate $($certName) does not exist in $($CAMConfig.KeyVault) KeyVault"
+        Write-ErrorLog -Message  "CAM: Certificate $($certName) does not exist in $($CAMConfig.KeyVault) KeyVault" -EventId 2008 -CAMConfig $CAMConfig         
         return
     }
     if ($Unstructured) {
@@ -679,7 +780,7 @@ param(
             $CertBytes = [System.Convert]::FromBase64String($CertJson.data)
         }
         catch {
-            write-output "CAM: Certificate $($CertName) has invalid JSON, Unable to install"
+            Write-ErrorLog -Message "CAM: Certificate $($CertName) has invalid JSON, Unable to install" -EventId 2010 -CAMConfig $CAMConfig                     
             return
         }
     }
@@ -695,7 +796,7 @@ param(
         }
     }
     catch {
-        write-output "CAM: Certificate $Certname could not be imported with password. Exception: $_"
+        Write-ErrorLog -Message "CAM: Certificate $Certname could not be imported with password. Exception: $_" -EventId 2009 -CAMConfig $CAMConfig         
         return
     }
     $Pfx.FriendlyName = $CertName
@@ -712,7 +813,7 @@ param(
         Thumbprint=$pfx.Thumbprint
     }
     $Pfx.Dispose()
-    write-output "CAM: Installed Certificate $($CertName) to $CertStoreLocation\$CertStoreName store"
+    Write-InfoLog -Message "CAM: Installed Certificate $($CertName) to $CertStoreLocation\$CertStoreName store" -EventId 1007 -CAMConfig $CAMConfig             
     if ($ReturnOutput) {
         return $Output
     }
@@ -780,10 +881,11 @@ param(
             try {
                 #find the certificate with the earliest expiry of those matching the CertName parameter
                 $CertLocation = (Get-ChildItem "Cert:\$CertStoreLocation\$CertStoreName" | Where-Object {$_.FriendlyName -match $CertName} | Sort-Object -Property NotAfter)[0].PSPath
-                Write-Output "CAM: Certificate Thumbprint not provided for $CertName, attempting to delete certificate with earliest expiry."
+                Write-WarningLog -Message "CAM: Certificate Thumbprint not provided for $CertName, attempting to delete certificate with earliest expiry." `
+                    -EventId 2011 -CAMConfig $CAMConfig             
             }
             catch {
-                write-output "CAM: Certificate $($CertName) does not exist in $($CertStoreLocation)\$($CertStoreName) store"
+                Write-ErrorLog -Message  "CAM: Certificate $($certName) does not exist in $($CAMConfig.KeyVault) KeyVault" -EventId 2008 -CAMConfig $CAMConfig         
             }
         }
         else {
@@ -792,14 +894,14 @@ param(
         }
         if (test-path $CertLocation) {
             Remove-Item $CertLocation
-            write-output "CAM: Certificate $($CertName) deleted from $($CertStoreLocation)\$($CertStoreName) store"
+            Write-InfoLog -Message  "CAM: Certificate $($CertName) deleted from $($CertStoreLocation)\$($CertStoreName) store" -EventId 1008 -CAMConfig $CAMConfig         
         }
         else {
-            write-output "CAM: Certificate $($CertName) does not exist in $($CertStoreLocation)\$($CertStoreName) store"
+            Write-ErrorLog -Message  "CAM: Certificate $($CertName) does not exist in $($CertStoreLocation)\$($CertStoreName) store" -EventId 2012 -CAMConfig $CAMConfig         
         }
     }
     catch {
-        write-output "CAM: Failed to delete certificate $($CertLocation). Exception: $_" 
+        Write-ErrorLog -Message "CAM: Failed to delete certificate $($CertLocation). Exception: $_" -EventId 2013 -CAMConfig $CAMConfig         
     }
 }
 
@@ -842,7 +944,7 @@ param(
                 $acl=(Get-Item $fullpath -ErrorAction Stop).GetAccessControl('Access')
             }
             catch {
-                write-output "CAM: Unable to find Machine Key path for certificate $($CertName), Grant-CertificateAccess failed."
+                Write-ErrorLog -Message "CAM: Unable to find Machine Key path for certificate $($CertName), Grant-CertificateAccess failed." -EventId 2014 -CAMConfig $CAMConfig                         
                 return
             }
             $permission=$User, "Read", "Allow"
@@ -850,15 +952,16 @@ param(
 	        $acl.SetAccessRule($accessRule)
             try {
                 Set-Acl -Path $fullPath -AclObject $acl
-                Write-Output "CAM: Granted access to $User for certificate $CertName in $CertStoreLocation\$CertStoreName store."
+                Write-InfoLog -Message "CAM: Granted access to $User for certificate $CertName in $CertStoreLocation\$CertStoreName store." -EventId 1009 -CAMConfig $CAMConfig                         
             }
             catch {
-                Write-Output "CAM: Unable to grant access to $User for certificate $CertName in $CertStoreLocation\$CertStoreName store. Exception: $_"
+                Write-ErrorLog -Message "CAM: Unable to grant access to $User for certificate $CertName in $CertStoreLocation\$CertStoreName store. Exception: $_" `
+                    -EventId 2015 -CAMConfig $CAMConfig                         
             }
         }
     }
     catch {
-        Write-Output "CAM: Grant-CertificateAccess failed. Exception: $_"
+        Write-ErrorLog -Message "CAM: Grant-CertificateAccess failed. Exception: $_" -EventId 2016 -CAMConfig $CAMConfig                         
     }
 }
 
@@ -897,7 +1000,7 @@ param(
     }
     $Password = ''
     if (-not $Secret) {
-        write-output "CAM: Certificate $($certName) does not exist in $($CAMConfig.KeyVault) KeyVault"
+        Write-ErrorLog -Message  "CAM: Certificate $($certName) does not exist in $($CAMConfig.KeyVault) KeyVault" -EventId 2008 -CAMConfig $CAMConfig 
         return
     }
     if ($Unstructured) {
@@ -911,7 +1014,7 @@ param(
             $CertBytes = [System.Convert]::FromBase64String($CertJson.data)
         }
         catch {
-            write-output "CAM: Certificate $($CertName) has invalid JSON, Get-SecretThumbprint failed"
+            Write-ErrorLog -Message "CAM: Certificate $($CertName) has invalid JSON, Unable to install" -EventId 2010 -CAMConfig $CAMConfig                     
             return
         }
     }
@@ -919,7 +1022,7 @@ param(
         $Pfx = New-Object System.Security.Cryptography.X509Certificates.X509Certificate2($CertBytes, $Password, "PersistKeySet")
     }
     catch {
-        write-output "CAM: Certificate $Certname could not be imported with password. Exception: $_"
+        Write-ErrorLog -Message "CAM: Certificate $Certname could not be imported with password. Exception: $_" -EventId 2009 -CAMConfig $CAMConfig         
         return
     }
     $Thumbprint = $Pfx.Thumbprint
@@ -948,6 +1051,8 @@ param(
     }
     return $false
 }
+
+Export-ModuleMember -Function Write-InfoLog
 
 Export-ModuleMember -Function New-CamConfig
 

--- a/CAM.psm1
+++ b/CAM.psm1
@@ -70,8 +70,6 @@ function New-CAMConfig() {
 
 # LOG FUNCTIONS
 
-# END LOG FUNCTIONS
-
 function Write-InfoLog {
     param(
         [parameter(Mandatory=$true)]
@@ -146,8 +144,8 @@ function Write-CAMEventLog {
     }
 }
 
+# END LOG FUNCTIONS
 
-#>
 # SETUP FUNCTIONS
 
 # Script level variable for fallbacks during development, should store these in config or pass in to individual functions.
@@ -1051,8 +1049,6 @@ param(
     }
     return $false
 }
-
-Export-ModuleMember -Function Write-InfoLog
 
 Export-ModuleMember -Function New-CamConfig
 


### PR DESCRIPTION
Adding 4 functions to handle event log integration. All logs are still pushed to the output stream, error stream, or thrown in exceptions - however if a property is added to the CAMConfig enabling event logs, we will create them under the source "CertificateAllocationModule"